### PR TITLE
Design #23 for MC1.14.4

### DIFF
--- a/src/main/java/com/bettercolors/io/Filer.java
+++ b/src/main/java/com/bettercolors/io/Filer.java
@@ -117,7 +117,7 @@ public class Filer {
     }
 
     /**
-     * @return the settings directory ("bettercolors" folder in the minecraft game directory).
+     * @return the settings directory ("config" folder in the minecraft game directory).
      */
     public static File getSettingsDirectory() {
         String settingsDir = System.getProperty("user.dir");
@@ -125,7 +125,7 @@ public class Filer {
             throw new IllegalStateException("user.dir==null");
         }
         File home = new File(settingsDir);
-        File settingsDirectory = new File(home, "bettercolors");
+        File settingsDirectory = new File(home, "config");
         if(!settingsDirectory.exists()) {
             if(!settingsDirectory.mkdir()) {
                 throw new IllegalStateException(settingsDirectory.toString());

--- a/src/main/java/com/bettercolors/io/SettingsUtils.java
+++ b/src/main/java/com/bettercolors/io/SettingsUtils.java
@@ -12,7 +12,7 @@ import java.util.Map;
 
 public class SettingsUtils {
 
-    public static String SETTINGS_FILENAME = "default";
+    public static String SETTINGS_FILENAME = "bc_default";
 
     /**
      * It updates the configuration file with all the options given in [modules_options].


### PR DESCRIPTION
Changed settings directory from bettercolors/ to config/ and changed default config file by adding the "bc_" prefix.

! If the user wants to keep his settings, he has to move his current settings file from bettercolors/ to config/. And then he can use the settings tab to select his settings file.