### PR TITLE
Fix #40 for MC1.8.9

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -140,3 +140,4 @@ move your settings files to the config/ folder instead of the bettercolors/ fold
 - Added "write changelog of last version in console if the mod is out dated" (#30)
 - Increased the size of the console (100 -> 200)
 - Fixed wrong version difference computation (#39)
+- Only bettercolors' settings files are now shown in the settings selector (#40)

--- a/src/main/java/dev/nero/bettercolors/io/Filer.java
+++ b/src/main/java/dev/nero/bettercolors/io/Filer.java
@@ -16,6 +16,9 @@ public class Filer {
         if(!filename.endsWith(".properties")){
             filename += ".properties";
         }
+        if(!filename.startsWith("bc_")) {
+            filename = "bc_" + filename;
+        }
         FILENAME = filename;
     }
 

--- a/src/main/java/dev/nero/bettercolors/io/SettingsUtils.java
+++ b/src/main/java/dev/nero/bettercolors/io/SettingsUtils.java
@@ -12,7 +12,7 @@ import java.util.Map;
 
 public class SettingsUtils {
 
-    public static String SETTINGS_FILENAME = "bc_default";
+    public static String SETTINGS_FILENAME = "default";
 
     /**
      * It updates the configuration file with all the options given in [modules_options].
@@ -74,8 +74,10 @@ public class SettingsUtils {
         File[] files = folder.listFiles();
         if(files == null) return filenames;
         for(File file : files){
-            if(file.isFile() && file.getName().endsWith(".properties")){
-                filenames.addElement(file.getName().replace(".properties", ""));
+            if(file.isFile() && file.getName().endsWith(".properties") && file.getName().startsWith("bc_")){
+                String name = file.getName().replaceFirst("bc_", "");
+                name = name.replace(".properties", "");
+                filenames.addElement(name);
             }
         }
         return filenames;


### PR DESCRIPTION
The settings loader takes into account the bettercolors' settings files. And nothing else!
The files have the prefix "bc_". The settings loader show the settings without "bc_" prefix and ".properties" suffix